### PR TITLE
Correctly double-quote variables

### DIFF
--- a/export.sh
+++ b/export.sh
@@ -6,6 +6,9 @@ alfred_plist=~/Library/Preferences/com.runningwithcrayons.Alfred-Preferences.pli
 # Path to directory in which Alfred preferences are synced
 alfred_prefs_dir=$(defaults read "$alfred_plist" syncfolder 2> /dev/null)
 
+# Expand ~ to $HOME
+alfred_prefs_dir="${alfred_prefs_dir/#\~/$HOME}"
+
 # If no sync folder is set
 if [[ -z $alfred_prefs_dir ]]; then
 	# Use default location for preferences


### PR DESCRIPTION
Also remove useless use of eval and use `[[` instead of `[` (no matter which one you use, at least be consistent).
