### PR TITLE
Fix bug preventing installed workflow from being found

### DIFF
--- a/utilities/update-workflow.py
+++ b/utilities/update-workflow.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 import os
+import os.path
 import collections
 import plistlib
 import zipfile
@@ -58,9 +59,11 @@ def get_installation_dir(bundle_id):
 		# We need to read the plist with defaults
 		# as plistlib can't handle binary plists before Python 3.4
 		preference_dir = subprocess.check_output(['defaults', 'read', ALFRED_PLIST, 'syncfolder'], stderr=DEVNULL)
+
 		# Ensure ~ is expanded to full home folder path
 		# Also remove leading and trailing whitespace
 		preference_dir = os.path.expanduser(preference_dir.strip())
+
 	except subprocess.CalledProcessError:
 		# If syncfolder couldn't be read use the default preference dir
 		preference_dir = DEFAULT_ALFRED_PREFERENCE_DIR


### PR DESCRIPTION
Thanks again for the update script, @Tyilo. The script updates the project workflow file perfectly. However, it could not update the installed workflow file for the following reasons (as I've found):
1. If `syncfolder` has a value set in the Alfred plist:
   1. A preceding `~` does not expand to the home folder path
   2. A trailing newline prevented the value from being interpreted as a valid path

This pull request fixes both of these issues, thus enabling the script to update the installed workflow when a custom `syncfolder` is set. :)
