### PR TITLE
Reformat and reorganize codebase

### DIFF
--- a/actions/play.applescript
+++ b/actions/play.applescript
@@ -21,7 +21,7 @@ on playSong(songId)
 
 end playSong
 
--- plays songs belonging to the given album
+-- plays all songs belonging to the given album
 on playAlbum(albumName)
 
 	global config
@@ -49,7 +49,7 @@ on playArtist(artistName)
 
 end playArtist
 
--- plays all songs by the given genre
+-- plays all songs within the given genre
 on playGenre(genreName)
 
 	global config
@@ -63,7 +63,7 @@ on playGenre(genreName)
 
 end playGenre
 
--- plays songs in the given playlist
+-- plays all songs in the given playlist
 on playPlaylist(playlistId)
 
 	global config
@@ -81,32 +81,37 @@ on playPlaylist(playlistId)
 
 end playPlaylist
 
--- Given a query string splits it into the type and id
-on getTypeAndId(query)	set pos to offset of "-" in query
+-- parses the given query to retrieve type and id of item to play
+on parseQuery(query)
 
-	set type to text 1 thru (pos - 1) of query
-	set theId to text (pos + 1) thru -1 of query
-	return {type, theId}
-end getTypeAndId
+	set pos to offset of "-" in query
+	set theType to text 1 thru (pos - 1) of query
+	set theId to text (pos + 1) thru end of query
+	return {type:theType, id:theId}
 
+end parseQuery
+
+--
 on play(query)
-	set typeAndId to getTypeAndId(query)
-	set type to first item of typeAndId
-	set theId to last item of typeAndId
 
-	if type is equal to "song" then
+	set typeAndId to parseQuery(query)
+	set theType to type of typeAndId
+	set theId to id of typeAndId
+
+	if theType is "song" then
 		playSong(theId)
-	else if type is equal to "album" then
+	else if theType is "album" then
 		playAlbum(theId)
-	else if type is equal to "artist" then
+	else if theType is "artist" then
 		playArtist(theId)
-	else if type is equal to "genre" then
+	else if theType is "genre" then
 		playGenre(theId)
-	else if type is equal to "playlist" then
+	else if theType is "playlist" then
 		playPlaylist(theId)
 	else
-		log "Unknown type: " & type
-	end
+		log "Unknown type: " & theType
+	end if
+
 end play
 
 set config to loadConfig()

--- a/filters/playalbum.applescript
+++ b/filters/playalbum.applescript
@@ -1,6 +1,5 @@
 -- filters albums by the typed query --
 
--- loads workflow configuration
 on loadConfig()
 
 	do shell script "./compile-config.sh"
@@ -9,37 +8,29 @@ on loadConfig()
 
 end loadConfig
 
--- constructs album result list as XML string
 on getAlbumResultListXml(query)
 
 	global config
 
 	set query to trimWhitespace(query) of config
 
-	-- search iTunes library for the given query
 	tell application "iTunes"
 
 		set theAlbums to getResultsFromQuery(query, "album") of config
 
-		-- inform user that no results were found
-		if length of theAlbums is 0 then
+		repeat with albumName in theAlbums
+
+			set albumName to albumName as text
+			set theSong to (first track of playlist 2 whose album is albumName and kind contains (songDescriptor of config))
+			set songArtworkPath to getSongArtworkPath(theSong) of config
+
+			addResult({uid:("album-" & albumName), arg:("album-" & albumName), valid:"yes", title:albumName, subtitle:artist of theSong, icon:songArtworkPath}) of config
+
+		end repeat
+
+		if config's resultListIsEmpty() then
 
 			addNoResultsItem(query, "album") of config
-
-		else
-
-			-- loop through the results to create the XML data
-			repeat with albumName in theAlbums
-
-				set albumName to albumName as text
-				set theSong to (first track of playlist 2 whose album is albumName and kind contains (songDescriptor of config))
-
-				set songArtworkPath to getSongArtworkPath(theSong) of config
-
-				-- add song information to XML
-				addResult({uid:("album-" & albumName), arg:("album-" & albumName), valid:"yes", title:albumName, subtitle:artist of theSong, icon:songArtworkPath}) of config
-
-			end repeat
 
 		end if
 

--- a/filters/playalbumby.applescript
+++ b/filters/playalbumby.applescript
@@ -1,6 +1,5 @@
 -- filters albums by the typed query --
 
--- loads workflow configuration
 on loadConfig()
 
 	do shell script "./compile-config.sh"
@@ -9,47 +8,38 @@ on loadConfig()
 
 end loadConfig
 
--- constructs album result list as XML string
 on getAlbumResultListXml(query)
 
 	global config
 
 	set query to trimWhitespace(query) of config
 
-	-- search iTunes library for the given query
 	tell application "iTunes"
+
 		set theArtists to getResultsFromQuery(query, "artist") of config
-		
-		set empty to true
-		
+
 		repeat with artistName in theArtists
-			set artistName to artistName as text
-			
+
 			set artistAlbums to getArtistAlbums(artistName) of config
 
 			repeat with albumName in artistAlbums
-				if resultListIsFull() of config then
-					exit repeat
-				end if
-				
+
+				if config's resultListIsFull() then exit repeat
+
 				set albumName to albumName as text
 				set theSong to (first track of playlist 2 whose album is albumName and kind contains (songDescriptor of config))
 
 				set songArtworkPath to getSongArtworkPath(theSong) of config
 
-				-- add song information to XML
 				addResult({uid:("album-" & albumName), arg:("album-" & albumName), valid:"yes", title:albumName, subtitle:artist of theSong, icon:songArtworkPath}) of config
-				
-				set empty to false
+
 			end repeat
 
-			if resultListIsFull() of config then
-				exit repeat
-			end if
+			if config's resultListIsFull() then exit repeat
+
 		end repeat
 
-		-- inform user that no results were found
-		if empty then
+		if config's resultListIsEmpty() then
 
 			addNoResultsItem(query, "album") of config
 

--- a/filters/playartist.applescript
+++ b/filters/playartist.applescript
@@ -1,6 +1,5 @@
 -- filters artists by the typed query --
 
--- loads workflow configuration
 on loadConfig()
 
 	do shell script "./compile-config.sh"
@@ -9,37 +8,29 @@ on loadConfig()
 
 end loadConfig
 
--- constructs artist result list as XML string
 on getArtistResultListXml(query)
 
 	global config
 
 	set query to trimWhitespace(query) of config
 
-	-- search iTunes library for the given query
 	tell application "iTunes"
 
 		set theArtists to getResultsFromQuery(query, "artist") of config
 
-		-- inform user that no results were found
-		if length of theArtists is 0 then
+		repeat with artistName in theArtists
+
+			set artistName to artistName as text
+			set theSong to (first track of playlist 2 whose artist is artistName and kind contains (songDescriptor of config))
+			set songArtworkPath to getSongArtworkPath(theSong) of config
+
+			addResult({uid:("artist-" & artistName), arg:("artist-" & artistName), valid:"yes", title:artistName, subtitle:"Artist", icon:songArtworkPath}) of config
+
+		end repeat
+
+		if config's resultListIsEmpty() then
 
 			addNoResultsItem(query, "artist") of config
-
-		else
-
-			-- loop through the results to create the XML data
-			repeat with artistName in theArtists
-
-				set artistName to artistName as text
-				set theSong to (first track of playlist 2 whose artist is artistName and kind contains (songDescriptor of config))
-
-				set songArtworkPath to getSongArtworkPath(theSong) of config
-
-				-- add song information to XML
-				addResult({uid:("artist-" & artistName), arg:("artist-" & artistName), valid:"yes", title:artistName, subtitle:"Artist", icon:songArtworkPath}) of config
-
-			end repeat
 
 		end if
 

--- a/filters/playgenre.applescript
+++ b/filters/playgenre.applescript
@@ -1,6 +1,5 @@
 -- filters genres by the typed query --
 
--- loads workflow configuration
 on loadConfig()
 
 	do shell script "./compile-config.sh"
@@ -9,37 +8,29 @@ on loadConfig()
 
 end loadConfig
 
--- constructs genre result list as XML string
 on getGenreResultListXml(query)
 
 	global config
 
 	set query to trimWhitespace(query) of config
 
-	-- search iTunes library for the given query
 	tell application "iTunes"
 
 		set theGenres to getResultsFromQuery(query, "genre") of config
 
-		-- inform user that no results were found
-		if length of theGenres is 0 then
+		repeat with genreName in theGenres
+
+			set genreName to genreName as text
+			set theSong to (first track of playlist 2 whose genre is genreName and kind contains (songDescriptor of config))
+			set songArtworkPath to getSongArtworkPath(theSong) of config
+
+			addResult({uid:("genre-" & genreName), arg:("genre-" & genreName), valid:"yes", title:genreName, subtitle:"Genre", icon:songArtworkPath}) of config
+
+		end repeat
+
+		if config's resultListIsEmpty() then
 
 			addNoResultsItem(query, "genre") of config
-
-		else
-
-			-- loop through the results to create the XML data
-			repeat with genreName in theGenres
-
-				set genreName to genreName as text
-				set theSong to (first track of playlist 2 whose genre is genreName and kind contains (songDescriptor of config))
-
-				set songArtworkPath to getSongArtworkPath(theSong) of config
-
-				-- add song information to XML
-				addResult({uid:("genre-" & genreName), arg:("genre-" & genreName), valid:"yes", title:genreName, subtitle:"Genre", icon:songArtworkPath}) of config
-
-			end repeat
 
 		end if
 

--- a/filters/playplaylist.applescript
+++ b/filters/playplaylist.applescript
@@ -1,6 +1,5 @@
 -- filters playlists by the typed query --
 
--- loads workflow configuration
 on loadConfig()
 
 	do shell script "./compile-config.sh"
@@ -9,14 +8,12 @@ on loadConfig()
 
 end loadConfig
 
--- constructs playlist result list as XML string
 on getPlaylistResultListXml(query)
 
 	global config
 
 	set query to trimWhitespace(query) of config
 
-	-- search iTunes library for the given query
 	tell application "iTunes"
 
 		-- retrieve list of playlists matching query (ordered by relevance)
@@ -34,47 +31,38 @@ on getPlaylistResultListXml(query)
 
 		end if
 
-		-- inform user that no results were found
-		if length of thePlaylists is 0 then
+		if length of thePlaylists > config's resultLimit then
 
-			addNoResultsItem(query, "playlist") of config
+			set thePlaylists to items 1 thru (config's resultLimit) of thePlaylists
 
-		else
+		end if
 
-			set theIndex to 1
+		repeat with thePlaylist in thePlaylists
 
-			if length of thePlaylists > config's resultLimit then
+			set playlistName to name of thePlaylist
+			set playlistId to id of thePlaylist
+			set songCount to number of tracks in thePlaylist
 
-				set thePlaylists to items 1 thru (config's resultLimit) of thePlaylists
+			set theSong to (first track in user playlist playlistName whose kind contains (songDescriptor of config))
+			set songArtworkPath to getSongArtworkPath(theSong) of config
+
+			if songCount is 1 then
+
+				set itemSubtitle to "1 song"
+
+			else
+
+				set itemSubtitle to (songCount & " songs") as text
 
 			end if
 
-			-- loop through the results to create the XML data
-			repeat with thePlaylist in thePlaylists
+			addResult({uid:("playlist-" & playlistId) as text, arg:("playlist-" & playlistId) as text, valid:"yes", title:playlistName, subtitle:itemSubtitle, icon:songArtworkPath}) of config
 
-				set playlistName to name of thePlaylist
-				set playlistId to id of thePlaylist
+		end repeat
 
-				set theSong to (first track in user playlist playlistName whose kind contains (songDescriptor of config))
-				set songArtworkPath to getSongArtworkPath(theSong) of config
+		if config's resultListIsEmpty() then
 
-				-- determine number of songs in playlist
-				set songCount to number of tracks in thePlaylist
-
-				if songCount is 1 then
-
-					set itemSubtitle to "1 song"
-
-				else
-
-					set itemSubtitle to (songCount & " songs") as text
-
-				end if
-
-				-- add song information to XML
-				addResult({uid:("playlist-" & playlistId) as text, arg:("playlist-" & playlistId) as text, valid:"yes", title:playlistName, subtitle:itemSubtitle, icon:songArtworkPath}) of config
-
-			end repeat
+			addNoResultsItem(query, "playlist") of config
 
 		end if
 

--- a/filters/playsong.applescript
+++ b/filters/playsong.applescript
@@ -1,6 +1,5 @@
 -- filters songs by the typed query --
 
--- loads workflow configuration
 on loadConfig()
 
 	do shell script "./compile-config.sh"
@@ -9,44 +8,34 @@ on loadConfig()
 
 end loadConfig
 
--- constructs song result list as XML string
 on getSongResultListXml(query)
 
 	global config
 
 	set query to trimWhitespace(query) of config
 
-	-- search iTunes library for the given query
 	tell application "iTunes"
 
 		set theSongs to getResultsFromQuery(query, "name") of config
 
-		-- inform user that no results were found
-		if length of theSongs is 0 then
+		repeat with theSong in theSongs
+
+			if config's resultListIsFull() then exit repeat
+
+			set songId to (get database ID of theSong)
+			set songName to name of theSong
+			set songArtist to artist of theSong
+			set songAlbum to album of theSong
+			set songKind to kind of theSong
+			set songArtworkPath to getSongArtworkPath(theSong) of config
+
+			addResult({uid:("song-" & songId), arg:("song-" & songId), valid:"yes", title:songName, subtitle:songArtist, icon:songArtworkPath}) of config
+
+		end repeat
+
+		if config's resultListIsEmpty() then
 
 			addNoResultsItem(query, "song") of config
-
-		else
-
-			-- loop through the results to create the XML data
-			repeat with theSong in theSongs
-
-				-- limit number of results
-				if config's resultListIsFull() then exit repeat
-
-				-- get song information
-				set songId to (get database ID of theSong)
-				set songName to name of theSong
-				set songArtist to artist of theSong
-				set songAlbum to album of theSong
-				set songKind to kind of theSong
-
-				set songArtworkPath to getSongArtworkPath(theSong) of config
-
-				-- add song information to XML
-				addResult({uid:("song-" & songId), arg:("song-" & songId), valid:"yes", title:songName, subtitle:songArtist, icon:songArtworkPath}) of config
-
-			end repeat
 
 		end if
 

--- a/resources/config.applescript
+++ b/resources/config.applescript
@@ -4,7 +4,7 @@
 
 -- limit number of songs to improve efficiency
 property resultLimit : 9
--- whether or not to retrieve album artwork for each result
+-- whether or not to retrieve/display album artwork for each result
 property albumArtEnabled : true
 
 -- workflow parameters --
@@ -19,7 +19,7 @@ property artworkCacheFolderName : "Album Artwork"
 property artworkCachePath : (workflowCacheFolder & artworkCacheFolderName & ":")
 property songArtworkNameSep : " | "
 property defaultIconName : "icon-noartwork.png"
--- the name of the playlist this workflow uses for playing songs
+-- the name of the playlist used by the workflow for playing songs
 property workflowPlaylistName : "Alfred Play Song"
 -- the text used to determine if a track is an audio file
 property songDescriptor : "audio"
@@ -63,7 +63,7 @@ on decodeXmlChars(theString)
 
 end decodeXmlChars
 
--- adds result to result list
+-- adds Alfred result to result list
 on addResult(theResult)
 
 	copy theResult to the end of resultList
@@ -77,10 +77,15 @@ on addNoResultsItem(query, queryType)
 
 end addNoResultsItem
 
--- indicates if the result list is full
 on resultListIsFull()
 
 	return (length of resultList is resultLimit)
+
+end resultListIsFull
+
+on resultListIsEmpty()
+
+	return (length of resultList is 0)
 
 end resultListIsFull
 
@@ -213,19 +218,16 @@ on createWorkflowPlaylist()
 
 end createWorkflowPlaylist
 
--- empties song queue
 on emptyQueue()
 
 	tell application "iTunes"
 
-		-- empty queue
 		delete tracks of user playlist workflowPlaylistName
 
 	end tell
 
 end emptyQueue
 
--- adds songs to queue
 on queueSongs(theSongs)
 
 	tell application "iTunes"
@@ -240,12 +242,10 @@ on queueSongs(theSongs)
 
 end queueSongs
 
--- plays the queued songs
 on playQueue()
 
 	tell application "iTunes"
 
-		-- beginning playing songs in playlist if not empty
 		if number of tracks in user playlist workflowPlaylistName is not 0 then
 
 			play user playlist workflowPlaylistName
@@ -267,7 +267,6 @@ on focusQueue()
 
 end focusQueue
 
--- plays the given songs in the queue
 on playSongs(theSongs)
 
 	emptyQueue()
@@ -277,7 +276,7 @@ on playSongs(theSongs)
 
 end playSongs
 
--- disables shuffle mode for songs
+-- disables shuffle mode for songs within iTunes
 on disableShuffle()
 
 	try


### PR DESCRIPTION
Hi, @Tyilo.

Lately, I've been working on Play Song, cleaning up the codebase a bit. Below is an overview of most (if not all) of my changes:

* Converted all line breaks to unix-style (LF)
    * Please use these from now on or configure your editor to respect the project's *.editorconfig* settings
* Rewrote logic that determines when the "No Results" item is added
    * The reduced nesting and logical reorganization makes the code cleaner, more maintainable, and more future-proof
    * This also eliminates the need for the `empty` variable in the `playalbumby` filter
* Reformatted your recent code changes (particularly the *playalbumby* filter) to conform with the implicit style conventions for the project
    * Newlines surrounding start/end lines for control blocks (`if`, `repeat`, *etc.*)
    * Prefer `is` over `is equal to`
    * Config properties/functions whose names start with a noun should be preceded by `config's` (*e..g.* `config's resultList`, `config's resultListIsFull()`)
        * Similarly, config functions whose names start with a verb should be followed by `of config` (*e.g.* `addResult() of config`)
    * If you'd like, I can more formally establish these guidelines in the README or a CONTRIBUTING document
* Removed a number of useless comments (*i.e.* where the code logic speaks for itself)
    * This should reduce redundancy throughout the codebase, which will effectively reduce file size a little bit

Please let me know what you think. :)
Caleb