### PR TITLE
Add clearcache action

### DIFF
--- a/actions/clearcache.applescript
+++ b/actions/clearcache.applescript
@@ -1,0 +1,15 @@
+-- clears workflow cache, including album artwork and compiled scripts --
+
+on loadConfig()
+
+	set config to load script alias ((path to library folder from user domain as text) & "Caches:com.runningwithcrayons.Alfred-2:Workflow Data:com.calebevans.playsong:config.scpt")
+	return config
+
+end loadConfig
+
+set config to loadConfig()
+try
+	tell application "Finder"
+		delete folder (workflowCacheFolder of config)
+	end tell
+end try


### PR DESCRIPTION
A longtime Play Song user wrote to me recently asking how he could clear the workflow's album artwork cache. Of course, I told him how to delete the Play Song cache folder manually, but I have since decided it would be useful to have an easily-accessible `clearcache` action included in the workflow.

As you can see, I have added the AppleScript for this action. However, the workflow updater script will not allow me to add a new keyword and script filter to the workflow; the objects keep disappearing after I add them and run `./utilities/update-workflow.py`. @Tyilo, could you please fix this and create a PR so I can merge in the feature and push a new release?

Thanks,
Caleb