### PR TITLE
improve: let album search results show album artist in subtitle

### DIFF
--- a/filters/playalbum.applescript
+++ b/filters/playalbum.applescript
@@ -19,8 +19,15 @@ on getAlbumResultListFeedback(query)
 			set albumName to albumName as text
 			set theSong to (first track of playlist 2 whose album is albumName)
 			set songArtworkPath to getSongArtworkPath(theSong) of config
+			
+			set albumArtistValue to album artist of theSong
+			if albumArtistValue is not "" then
+				set subtitleValue to albumArtistValue
+			else
+				set subtitleValue to artist of theSong
+			end if
 
-			addResult({uid:("album-" & albumName), valid:"yes", title:albumName, subtitle:album artist of theSong, icon:songArtworkPath}) of config
+			addResult({uid:("album-" & albumName), valid:"yes", title:albumName, subtitle:subtitleValue, icon:songArtworkPath}) of config
 
 		end repeat
 

--- a/filters/playalbumby.applescript
+++ b/filters/playalbumby.applescript
@@ -36,8 +36,15 @@ on getAlbumResultListFeedback(query)
 
 			set theSong to (first track of playlist 2 whose album is albumName)
 			set songArtworkPath to getSongArtworkPath(theSong) of config
+			
+			set albumArtistValue to album artist of theSong
+			if albumArtistValue is not "" then
+				set subtitleValue to albumArtistValue
+			else
+				set subtitleValue to artist of theSong
+			end if
 
-			addResult({uid:("album-" & albumName), valid:"yes", title:albumName, subtitle:album artist of theSong, icon:songArtworkPath}) of config
+			addResult({uid:("album-" & albumName), valid:"yes", title:albumName, subtitle:subtitleValue, icon:songArtworkPath}) of config
 
 		end repeat
 


### PR DESCRIPTION
Currently the subtitle for an album item shows the artist field of the first song that the filter can find in that album. Might be unpredictable when the artists of songs across the same album differ. So It is better to show album artist instead of artist. 

Before:
<img width="764" height="172" alt="Screenshot 2025-07-27 at 2 59 05 PM" src="https://github.com/user-attachments/assets/0f206518-9a9e-47d8-a59e-b4ac4cd30536" />

After:
<img width="764" height="172" alt="Screenshot 2025-07-30 at 7 12 52 PM" src="https://github.com/user-attachments/assets/0a7c6836-239c-4702-accf-186806a209c0" />

Niagara Fallin’ Stars produced this [multi-artist album](https://ja.wikipedia.org/wiki/LET%27S_ONDO_AGAIN), in which Amigo Nunoya was involved solely in the final track.