### PR TITLE
fix: Normalize query to NFC

### DIFF
--- a/resources/config.applescript
+++ b/resources/config.applescript
@@ -438,6 +438,9 @@ end getSong
 -- retrieves a list of objects or names matching the given query and type
 on getResultsFromQuery(query, queryType)
 
+	-- Normalize query to NFC so it matches how Music.app stores Unicode strings.
+	set query to do shell script "python3 -c \"import unicodedata,sys; print(unicodedata.normalize('NFC', sys.argv[1]), end='')\" " & quoted form of query
+
 	-- Special handling for artist queries to search across multiple fields
 	if queryType is "artist" then
 		set evalScript to run script "


### PR DESCRIPTION
Difference between how Alfred passes queries and how Music.app stores the titles might cause some songs to not appear in the results:

<img width="764" height="540" alt="Screenshot 2026-02-24 at 12 27 23 AM" src="https://github.com/user-attachments/assets/75c4201b-9c79-4342-bc3d-689e283afdb5" />

I have a song called ‘アポリア’ in my library but I couldn’t find it by typing the full title:

<img width="764" height="172" alt="Screenshot 2026-02-24 at 12 27 11 AM" src="https://github.com/user-attachments/assets/c88ffac9-b273-449d-bc59-ef78ca92d976" />

After the normalization I was able to find this song by its full title.

<img width="764" height="172" alt="Screenshot 2026-02-24 at 1 14 06 AM" src="https://github.com/user-attachments/assets/1e483671-f2f3-479a-ba7d-e26696b3d50b" />

But since I don't know much about Unicode normalization and this fix needs to be tested more, I'll mark this as a draft for now. 